### PR TITLE
Add sudospawner + kerberos example

### DIFF
--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -45,7 +45,11 @@ RUN mkdir -p /opt/jupyterhub && \
 
 # Add the jupyterhub config
 COPY jupyterhub_config.py /opt/jupyterhub/
+COPY jupyterhub_sudo_config.py /opt/jupyterhub/
 COPY hub.sh /opt/jupyterhub/
+
+# Add custom sudospawner script
+COPY sudospawner-singleuser /opt/conda/bin/
 
 EXPOSE 8000
 WORKDIR /opt/jupyterhub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,4 @@ services:
       - kdc
     user: jupyter
     command:
-      ./hub.sh --JupyterHub.spawner_class='sudospawner.SudoSpawner' --SudoSpawner.sudospawner_path='/opt/conda/bin/sudospawner'
+      ./hub.sh --config=jupyterhub_sudo_config.py

--- a/jupyterhub_sudo_config.py
+++ b/jupyterhub_sudo_config.py
@@ -1,0 +1,70 @@
+# Set the Hub to listen on all interfaces in the container on port 8000
+c.JupyterHub.ip = '0.0.0.0'
+c.JupyterHub.port = 8000
+
+# The authenticator can call pam_open_session before spawning a notebook server
+# and pam_close_session when shutting one down. With pam_krb5, this results
+# in a log message stating:
+    # Nov 15 14:22:28 workbook python: pam_krb5(login:session):
+    # (user bob) unable to get PAM_KRB5CCNAME, assuming non-Kerberos login
+# most likely because the pam_authentication and pam_setcreds calls are
+# happening in a wholly separate pam transaction where the env var is set.
+# So opening sessions has no impact on Kerberos ticketing in the current Hub
+# design for auth and spawn.
+c.PAMAuthenticator.open_sessions = False
+
+from sudospawner import SudoSpawner
+from traitlets import default
+
+from jupyterhub.auth import PAMAuthenticator
+import pamela
+from tornado import gen
+
+class KerberosPAMAuthenticator(PAMAuthenticator):
+    @gen.coroutine
+    def authenticate(self, handler, data):
+        """Authenticate with PAM, and return the username if login is successful.
+
+        Return None otherwise.
+
+        Do not establish a credential cache when authenticating the user.
+        The unprivileged user that owns the hub process cannot chown the ccache
+        to the target user anyway.
+        """
+        username = data['username']
+        try:
+            pamela.authenticate(username, data['password'], service=self.service, resetcred=False)
+        except pamela.PAMError as e:
+            if handler is not None:
+                self.log.warning("PAM Authentication failed (%s@%s): %s", username, handler.request.remote_ip, e)
+            else:
+                self.log.warning("PAM Authentication failed: %s", e)
+        else:
+            return username
+
+c.JupyterHub.authenticator_class = KerberosPAMAuthenticator
+
+class KerberosSudoSpawner(SudoSpawner):
+    @default('options_form')
+    def _options_form(self):
+        return '''\
+<label for="args">Kerberos Password</label>
+<input name="password" type="password"></input>
+'''
+
+    def options_from_form(self, formdata):
+        """Turn html formdata (always lists of strings) into the dict we want."""
+        options = {}
+        password = formdata.get('password', [''])[0].strip()
+        if password:
+            options['password'] = password
+        return options
+
+    def get_env(self):
+        env = super().get_env()
+        env['KERBEROS_PASSWORD'] = self.user_options['password']
+        return env
+
+# Use the kerberos sudo spawner.
+c.JupyterHub.spawner_class = KerberosSudoSpawner
+c.SudoSpawner.sudospawner_path = '/opt/conda/bin/sudospawner'

--- a/sudospawner-singleuser
+++ b/sudospawner-singleuser
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+source /opt/conda/bin/activate /opt/conda
+# Use pamela to do authentication again, this time after sudoing to the desired notebook
+# server user so that the kerberos cred cache is created and the chown is a no-op.
+python -c "import pamela
+import getpass
+import os
+pamela.authenticate(getpass.getuser(), os.getenv('KERBEROS_PASSWORD'), resetcred=0x0002)"
+# Clear the kerberos password that we set in the environment in our custom spawner so that
+# its not visible to the notebook server and kernels.
+unset KERBEROS_PASSWORD
+# Delegate launch to the notebook server.
+exec "$(dirname "$0")/jupyterhub-singleuser" $@


### PR DESCRIPTION
Prompt the user for his/her kerberos password at spawn time so that a
Kerberos cred cache can be established on disk and chowned to the target
user. The chown cannot be done by the unprivileged user that owns the
hub process, so we skip cred cache creation at login time and instead do
it at spawn time after sudo'ing to the the target user (effectively
making the chown a no-op).