### PR TITLE
pin versions for issue #4

### DIFF
--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -21,11 +21,12 @@ RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.s
 
 RUN /opt/conda/bin/conda install --yes -c conda-forge \
     python=3.5 \
-    configurable-http-proxy \
-    notebook \
-    jupyterhub \
+    configurable-http-proxy=3.0.0 \
+    notebook=5.1.0 \
+    idna=2.5 \
+    jupyterhub=0.7.2 \
     'pamela>=0.3' \
-    sudospawner && \
+    sudospawner=0.4.1 && \
     /opt/conda/bin/conda clean -tipsy
 
 # Configure kerberos

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -21,8 +21,7 @@ RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.s
 
 RUN /opt/conda/bin/conda install --yes -c conda-forge \
     python=3.5 \
-    configurable-http-proxy=3.0.0 \
-    notebook=5.1.0 \
+    notebook=5.0.0 \
     idna=2.5 \
     jupyterhub=0.7.2 \
     'pamela>=0.3' \


### PR DESCRIPTION
This PR will pin the versions to versions known to build today.  Not certain these versions were tested when this project was created, but with the 0.8.0 version of jupyterhub imminent but not available yet, then the 0.7.2 dependency should have been tested at some point. 

NOTE: I had to pin idna to 2.5 because for some strange reason when I added 0.7.2 version to jupyterhub it tried to pull in version 2.6 and that is not available in conda.  Leaving the version unspecified was pulling in version 0.7.2 of hub, but version 2.5 of idna.  Not sure why...